### PR TITLE
Make `worker_inactive_timeout` and `worker_monitoring_interval` configurable separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/network-scheduler/Cargo.toml
+++ b/crates/network-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-scheduler"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 
 [dependencies]

--- a/crates/network-scheduler/config.yml
+++ b/crates/network-scheduler/config.yml
@@ -16,6 +16,7 @@
 
 schedule_interval_epochs: 6
 worker_inactive_timeout_sec: 600
+worker_monitoring_interval_sec: 60
 worker_stale_timeout_sec: 900
 worker_unreachable_timeout_sec: 300
 failed_dial_retry_sec: 60

--- a/crates/network-scheduler/src/cli.rs
+++ b/crates/network-scheduler/src/cli.rs
@@ -20,6 +20,9 @@ pub struct Config {
     #[serde(rename = "worker_inactive_timeout_sec")]
     pub worker_inactive_timeout: Duration,
     #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "worker_monitoring_interval_sec")]
+    pub worker_monitoring_interval: Duration,
+    #[serde_as(as = "DurationSeconds")]
     #[serde(rename = "worker_stale_timeout_sec")]
     pub worker_stale_timeout: Duration,
     #[serde_as(as = "DurationSeconds")]
@@ -45,10 +48,6 @@ impl Config {
     #[inline(always)]
     pub fn get() -> &'static Self {
         CONFIG.get().expect("Config not initialized")
-    }
-
-    pub fn worker_monitoring_interval(&self) -> Duration {
-        self.worker_inactive_timeout / 2
     }
 }
 

--- a/crates/network-scheduler/src/server.rs
+++ b/crates/network-scheduler/src/server.rs
@@ -212,7 +212,7 @@ impl Server {
         let scheduler = self.scheduler.clone();
         let metrics_writer = self.metrics_writer.clone();
         let transport_handle = self.transport_handle.clone();
-        let interval = Config::get().worker_monitoring_interval();
+        let interval = Config::get().worker_monitoring_interval;
 
         let task = move |cancel_token: CancellationToken| {
             let scheduler = scheduler.clone();


### PR DESCRIPTION
See #12 