### PR TITLE
Fix jailing for not downloading just assigned chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/network-scheduler/Cargo.toml
+++ b/crates/network-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-scheduler"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/network-scheduler/src/scheduler.rs
+++ b/crates/network-scheduler/src/scheduler.rs
@@ -169,10 +169,13 @@ impl Scheduler {
                     .get_mut(&unit_id)
                     .expect("No assignment entry for unit")
                     .retain(|worker_id| {
-                        self.worker_states
+                        let worker = self
+                            .worker_states
                             .get_mut(worker_id)
-                            .expect("Unknown worker")
-                            .try_expand_unit(&unit_id, old_size, unit_size)
+                            .expect("Unknown worker");
+                        let retained = worker.try_expand_unit(&unit_id, old_size, unit_size);
+                        worker.reset_download_progress(&self.known_units);
+                        retained
                     });
             }
         }

--- a/crates/network-scheduler/src/worker_state.rs
+++ b/crates/network-scheduler/src/worker_state.rs
@@ -155,7 +155,7 @@ impl WorkerState {
         }
     }
 
-    /// Assigned unit's size has increased. Unassing the unit if it doesn't fit anymore.
+    /// Assigned unit's size has increased. Unassign the unit if it doesn't fit anymore.
     /// Return true iff the unit remained assigned.
     pub fn try_expand_unit(&mut self, unit_id: &UnitId, old_size: u64, new_size: u64) -> bool {
         let size_diff = new_size - old_size;


### PR DESCRIPTION
If the scheduling unit got expanded, it didn't reset the download progress. As a result, sometimes we could expand a unit and immediately jail all the workers that had it, even before sending a new assignment.