### PR TITLE
Add prometheus metrics related to units assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4327,6 +4327,7 @@ dependencies = [
  "hmac",
  "iter_num_tools",
  "itertools 0.12.1",
+ "lazy_static",
  "log",
  "nonempty",
  "prometheus-client",

--- a/crates/network-scheduler/Cargo.toml
+++ b/crates/network-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-scheduler"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [dependencies]
@@ -18,6 +18,7 @@ hex = "0.4"
 hmac = "0.12.1"
 iter_num_tools = "0.7"
 itertools = "0.12"
+lazy_static = "1.4.0"
 log = "0.4"
 nonempty = { version = "0.10", features = ["serde", "serialize"] }
 prometheus-client = "0.22"

--- a/crates/network-scheduler/src/main.rs
+++ b/crates/network-scheduler/src/main.rs
@@ -13,6 +13,7 @@ mod cli;
 mod data_chunk;
 mod metrics;
 mod metrics_server;
+mod prometheus_metrics;
 mod scheduler;
 mod scheduling_unit;
 mod server;
@@ -41,6 +42,7 @@ async fn main() -> anyhow::Result<()> {
     let metrics_writer = MetricsWriter::from_cli(&args).await?;
     let mut metrics_registry = Registry::default();
     subsquid_network_transport::metrics::register_metrics(&mut metrics_registry);
+    prometheus_metrics::register_metrics(&mut metrics_registry);
 
     // Build P2P transport
     let transport_builder = P2PTransportBuilder::from_cli(args.transport).await?;

--- a/crates/network-scheduler/src/metrics_server.rs
+++ b/crates/network-scheduler/src/metrics_server.rs
@@ -42,10 +42,7 @@ async fn chunks(
     let assigned_ranges = workers
         .iter()
         .flat_map(|w| {
-            let chunks = w
-                .assigned_units
-                .iter()
-                .flat_map(|unit_id| units.get(unit_id).unwrap().clone());
+            let chunks = w.assigned_chunks(&units);
             chunks_to_worker_state(chunks)
                 .datasets
                 .into_iter()

--- a/crates/network-scheduler/src/prometheus_metrics.rs
+++ b/crates/network-scheduler/src/prometheus_metrics.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::metrics::histogram::{linear_buckets, Histogram};
+use prometheus_client::registry::Registry;
+
+use crate::scheduling_unit::UnitId;
+
+lazy_static::lazy_static! {
+    static ref WORKERS_PER_UNIT: Histogram = Histogram::new(linear_buckets(0.0, 1.0, 100));
+    static ref TOTAL_UNITS: Gauge = Default::default();
+    static ref ACTIVE_WORKERS: Gauge = Default::default();
+    static ref REPLICATION_FACTOR: Gauge = Default::default();
+    static ref PARTIALLY_ASSIGNED_UNITS: Gauge = Default::default();
+}
+
+pub fn register_metrics(registry: &mut Registry) {
+    let registry = registry.sub_registry_with_prefix("scheduler");
+    registry.register(
+        "workers_per_unit",
+        "Number of workers that a scheduling unit is assigned to",
+        WORKERS_PER_UNIT.clone(),
+    );
+    registry.register(
+        "total_units",
+        "Total number of known units",
+        TOTAL_UNITS.clone(),
+    );
+    registry.register(
+        "active_workers",
+        "Number of active workers",
+        ACTIVE_WORKERS.clone(),
+    );
+    registry.register(
+        "replication_factor",
+        "Current replication factor",
+        REPLICATION_FACTOR.clone(),
+    );
+    registry.register(
+        "partially_assigned_units",
+        "Number of units that are missing some replicas",
+        PARTIALLY_ASSIGNED_UNITS.clone(),
+    );
+}
+
+pub fn units_assigned(counts: HashMap<&UnitId, usize>) {
+    for (_unit_id, count) in counts {
+        WORKERS_PER_UNIT.observe(count as f64);
+    }
+}
+
+pub fn total_units(count: usize) {
+    TOTAL_UNITS.set(count as i64);
+}
+
+pub fn active_workers(count: usize) {
+    ACTIVE_WORKERS.set(count as i64);
+}
+
+pub fn replication_factor(factor: usize) {
+    REPLICATION_FACTOR.set(factor as i64);
+}
+
+pub fn partially_assigned_units(count: usize) {
+    PARTIALLY_ASSIGNED_UNITS.set(count as i64);
+}


### PR DESCRIPTION
Adds the following metrics recalculated on each assignment:
- `scheduler_workers_per_unit` (histogram)
- `scheduler_total_units` (gauge)
- `scheduler_active_workers` (gauge)
- `scheduler_replication_factor` (gauge)
- `scheduler_partially_assigned_units` (gauge)