### PR TITLE
Add recommended worker versions to scheduler's config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/network-scheduler/Cargo.toml
+++ b/crates/network-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-scheduler"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/network-scheduler/config.yml
+++ b/crates/network-scheduler/config.yml
@@ -35,3 +35,5 @@ dataset_buckets:
   - base-1
   - moonbeam-evm-1
 scheduler_state_bucket: network-scheduler-state-test
+supported_worker_versions: ">=1.0.0-rc3"
+recommended_worker_versions: ">=1.0.0"

--- a/crates/network-scheduler/src/cli.rs
+++ b/crates/network-scheduler/src/cli.rs
@@ -57,6 +57,8 @@ pub struct Config {
     pub cloudflare_storage_secret: String,
     #[serde(default = "default_worker_version")]
     pub supported_worker_versions: VersionReq,
+    #[serde(default = "default_worker_version")]
+    pub recommended_worker_versions: VersionReq,
 }
 
 impl Config {


### PR DESCRIPTION
We want to automatically show notification to the owners of the outdated workers.\
For now, this value will be fetched from the `/config` endpoint by the Network App. Later we could also send a warning to outdated workers and show it in their logs/metrics.