### PR TITLE
Publish chunks list periodically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/network-scheduler/Cargo.toml
+++ b/crates/network-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-scheduler"
-version = "1.0.20"
+version = "1.0.21"
 edition = "2021"
 
 [dependencies]

--- a/crates/network-scheduler/src/metrics_server.rs
+++ b/crates/network-scheduler/src/metrics_server.rs
@@ -12,7 +12,7 @@ use subsquid_network_transport::util::CancellationToken;
 use tokio::sync::RwLock;
 
 use crate::cli::Config;
-use crate::scheduler::{ChunkStatus, Scheduler};
+use crate::scheduler::{ChunksSummary, Scheduler};
 use crate::worker_state::WorkerState;
 
 const JAIL_INFO_FIELDS: [Field<'static, WorkerState>; 3] = [
@@ -34,9 +34,7 @@ async fn workers_jail_info(Extension(scheduler): Extension<Scheduler>) -> Respon
     Json(jail_info).into_response()
 }
 
-async fn chunks(
-    Extension(scheduler): Extension<Scheduler>,
-) -> Json<HashMap<String, Vec<ChunkStatus>>> {
+async fn chunks(Extension(scheduler): Extension<Scheduler>) -> Json<ChunksSummary> {
     let chunks_summary = scheduler.get_chunks_summary();
     Json(chunks_summary)
 }

--- a/crates/network-scheduler/src/scheduler.rs
+++ b/crates/network-scheduler/src/scheduler.rs
@@ -38,12 +38,14 @@ pub struct ChunkStatus {
     pub downloaded_by: Vec<Arc<str>>, // Will deserialize duplicated, but it's short-lived
 }
 
+pub type ChunksSummary = HashMap<String, Vec<ChunkStatus>>; // dataset -> chunks statuses
+
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Scheduler {
     known_units: Arc<DashMap<UnitId, SchedulingUnit>>,
     units_assignments: Arc<DashMap<UnitId, Vec<PeerId>>>,
     worker_states: Arc<DashMap<PeerId, WorkerState>>,
-    chunks_summary: Arc<RwLock<HashMap<String, Vec<ChunkStatus>>>>, // dataset -> chunks statuses
+    chunks_summary: Arc<RwLock<ChunksSummary>>,
     last_schedule_epoch: Arc<AtomicU32>,
 }
 
@@ -527,11 +529,11 @@ impl Scheduler {
         prometheus_metrics::exec_time("assign_units", start.elapsed());
     }
 
-    pub fn get_chunks_summary(&self) -> HashMap<String, Vec<ChunkStatus>> {
+    pub fn get_chunks_summary(&self) -> ChunksSummary {
         self.chunks_summary.read().clone()
     }
 
-    pub fn update_chunks_summary(&self, summary: HashMap<String, Vec<ChunkStatus>>) {
+    pub fn update_chunks_summary(&self, summary: ChunksSummary) {
         *self.chunks_summary.write() = summary;
     }
 }


### PR DESCRIPTION
This file will be read by gateways (portals) to get information about chunk bounds. This is not intended to be used for optimizing ping/pong sizes — another solution will address that problem.