### PR TITLE
Add metadata to the last dataset chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -80,6 +80,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -92,6 +94,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -188,6 +205,98 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow-array"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a4a6d2896083cfbdf84a71a863b22460d0708f8206a8373c52e326cc72ea1a"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef870583ce5e4f3b123c181706f2002fb134960f9a911900f64ba4830c7a43a"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac7eba5a987f8b4a7d9629206ba48e19a1991762795bbe5d08497b7736017ee"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b095e8a4f3c309544935d53e04c3bfe4eea4e71c3de6fe0416d1f08bb4441a83"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c63da4afedde2b25ef69825cd4663ca76f78f79ffe2d057695742099130ff6"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f40f6be8f78af1ab610db7d9b236e21d587b7168e368a36275d2e5670096735"
+
+[[package]]
+name = "arrow-select"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac265273864a820c4a179fc67182ccc41ea9151b97024e1be956f0f2369c2539"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
 
 [[package]]
 name = "ascii-canvas"
@@ -323,6 +432,15 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1356,6 +1474,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1922,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_format"
@@ -2871,6 +3030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,8 +3299,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3226,6 +3407,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
 ]
 
 [[package]]
@@ -3908,6 +4100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4285,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,7 +4370,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom",
+ "getrandom 0.2.15",
  "libp2p-allow-block-list",
  "libp2p-autonat",
  "libp2p-connection-limits",
@@ -4262,7 +4524,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "getrandom",
+ "getrandom 0.2.15",
  "hashlink",
  "hex_fmt",
  "libp2p-core",
@@ -4688,6 +4950,9 @@ name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "match_cfg"
@@ -4755,7 +5020,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -4766,7 +5031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -4933,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "network-scheduler"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4947,6 +5212,7 @@ dependencies = [
  "crypto_box",
  "curve25519-dalek",
  "dashmap",
+ "derivative",
  "derive-enum-from-into",
  "env_logger",
  "flate2",
@@ -4961,6 +5227,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
+ "parquet",
  "prometheus-client",
  "rand 0.8.5",
  "random_choice",
@@ -4975,6 +5242,7 @@ dependencies = [
  "sqd-contract-client",
  "sqd-messages",
  "sqd-network-transport",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "url",
@@ -5060,12 +5328,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -5081,6 +5372,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5242,6 +5544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5319,6 +5630,40 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parquet"
+version = "54.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761c44d824fe83106e0600d2510c07bf4159a4985bf0569b513ea4288dc1b4fb"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.15.2",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd 0.13.2",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -5811,7 +6156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -5845,7 +6190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -5940,7 +6285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
+ "getrandom 0.2.15",
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash",
@@ -6047,7 +6392,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -6124,7 +6469,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -6292,7 +6637,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -6763,6 +7108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+
+[[package]]
 name = "serde"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7054,6 +7405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7139,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.2.1"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=ea97780#ea97780273000c4f0edab62b175e99db2acba31f"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=4b4c3c5#4b4c3c559490ab72f625e14e05e27aa93306609d"
 dependencies = [
  "async-trait",
  "clap",
@@ -7158,7 +7515,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.0.1"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=ea97780#ea97780273000c4f0edab62b175e99db2acba31f"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=4b4c3c5#4b4c3c559490ab72f625e14e05e27aa93306609d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7185,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.0.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=ea97780#ea97780273000c4f0edab62b175e99db2acba31f"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=4b4c3c5#4b4c3c559490ab72f625e14e05e27aa93306609d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7424,13 +7781,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -7515,6 +7872,17 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -7891,6 +8259,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8031,7 +8409,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -8041,7 +8419,7 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -8108,6 +8486,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -8583,6 +8970,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8858,7 +9254,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -8867,7 +9263,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -8877,6 +9282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "ea97780",  version = "1.2.0" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "ea97780", version = "2.0.0", features = ["bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "ea97780", version = "3.0.0" }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "4b4c3c5",  version = "1.2.0" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "4b4c3c5", version = "2.0.1", features = ["bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "4b4c3c5", version = "3.0.0" }

--- a/crates/network-scheduler/Cargo.toml
+++ b/crates/network-scheduler/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "network-scheduler"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-sdk-s3 = "1"
+aws-sdk-s3 = { version = "1", features = ["rt-tokio"] }
 axum = { version = "0.7", features = ["json"] }
 base64 = "0.22.1"
 bs58 = "0.5.1"
@@ -17,6 +17,7 @@ crypto_box = "0.9.1"
 curve25519-dalek = "4.1.3"
 dashmap = { version = "6", features = ["serde"] }
 derive-enum-from-into = "0.1"
+derivative = "2.2.0"
 env_logger = "0.11"
 flate2 = "1.0"
 futures = "0.3"
@@ -30,6 +31,7 @@ nonempty = { version = "0.10", features = ["serde", "serialize"] }
 num_cpus = "1"
 once_cell = "1"
 parking_lot = { version = "0.12", features = ["serde"] }
+parquet = "54.2"
 prometheus-client = "0.22"
 rand = "0.8"
 random_choice = "0.3"
@@ -41,6 +43,7 @@ serde_with = { version = "3.11", features = ["base64", "hex"] }
 serde_yaml = "0.9"
 sha2 = "0.10.8"
 sha3 = "0.10"
+tempfile = "3.17.1"
 tokio = { version = "1", features = ["full"] }
 url = "2.5.0"
 

--- a/crates/network-scheduler/src/data_chunk.rs
+++ b/crates/network-scheduler/src/data_chunk.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{hex::Hex, serde_as};
 use sha3::{Digest, Sha3_256};
 
-use sqd_messages::Range;
+use sqd_messages::{assignments, Range};
 
 use crate::cli::Config;
 
@@ -20,7 +20,8 @@ impl Display for ChunkId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, derivative::Derivative)]
+#[derivative(PartialEq)]
 pub struct DataChunk {
     #[serde(alias = "dataset_url")]
     pub dataset_id: String,
@@ -31,6 +32,8 @@ pub struct DataChunk {
     pub chunk_str: String,
     #[serde(default)]
     pub filenames: Vec<String>,
+    #[derivative(PartialEq = "ignore")]
+    pub summary: Option<assignments::ChunkSummary>,
     #[serde(skip)]
     id: OnceCell<ChunkId>,
 }
@@ -62,6 +65,7 @@ impl DataChunk {
             size_bytes,
             filenames,
             id: Default::default(),
+            summary: None,
         })
     }
 
@@ -89,6 +93,7 @@ mod tests {
             size_bytes: 0,
             chunk_str: "/00000/00001-01000-fa1f6773".to_string(),
             filenames: vec![],
+            summary: None,
             id: Default::default(),
         };
         assert_eq!(chunk.to_string(), "s3://squidnet/0-1000");

--- a/crates/network-scheduler/src/main.rs
+++ b/crates/network-scheduler/src/main.rs
@@ -11,6 +11,7 @@ use crate::storage::S3Storage;
 mod cli;
 mod data_chunk;
 mod metrics_server;
+mod parquet;
 mod prometheus_metrics;
 mod scheduler;
 mod scheduling_unit;

--- a/crates/network-scheduler/src/parquet.rs
+++ b/crates/network-scheduler/src/parquet.rs
@@ -1,47 +1,69 @@
 use parquet::file::reader::{FileReader, SerializedFileReader};
-use parquet::record::{Field, Row};
+use parquet::record::Field;
+use parquet::schema::types::Type;
 use sqd_messages::assignments;
 use std::fs::File;
 
 pub fn read_chunk_summary(blocks_file: File) -> anyhow::Result<assignments::ChunkSummary> {
-    let Some(last_row) = read_last_row(blocks_file)? else {
-        anyhow::bail!("Empty blocks file");
-    };
-    let mut hash = None;
-    let mut slot = None;
-    let mut number = None;
-    for column in last_row.into_columns() {
-        match column {
-            (name, Field::Str(s)) if name == "hash" => {
-                hash = Some(s);
-            }
-            (name, Field::Int(n)) if name == "number" => {
-                number = Some(n as u64);
-            }
-            (name, Field::Long(n)) if name == "slot" => {
-                slot = Some(n as u64);
-            }
-            _ => {}
+    let reader = SerializedFileReader::new(blocks_file)?;
+    let mut iter = read_blocks(&reader)?;
+    let mut last_block = iter
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No blocks found"))??;
+    for block in iter {
+        let block = block?;
+        if block.number > last_block.number {
+            last_block = block;
         }
     }
     Ok(assignments::ChunkSummary {
-        last_block_hash: hash.ok_or(anyhow::anyhow!("No hash of last block found"))?,
-        last_block_number: slot
-            .or(number)
-            .ok_or(anyhow::anyhow!("No number of last block found",))?,
+        last_block_hash: last_block.hash,
+        last_block_number: last_block.slot.unwrap_or(last_block.number),
     })
 }
 
-fn read_last_row(parquet: File) -> anyhow::Result<Option<Row>> {
-    let reader = SerializedFileReader::new(parquet)?;
+struct BlockSummary {
+    hash: String,
+    number: u64,
+    slot: Option<u64>,
+}
 
+fn read_blocks(
+    reader: &impl FileReader,
+) -> anyhow::Result<impl Iterator<Item = anyhow::Result<BlockSummary>> + '_> {
     let metadata = reader.metadata();
-    let num_row_groups = metadata.num_row_groups();
-    if num_row_groups == 0 {
-        return Ok(None);
-    }
+    let mut fields = metadata.file_metadata().schema().get_fields().to_vec();
+    fields.retain(|f| matches!(f.name(), "number" | "hash" | "slot"));
+    let projection = Type::group_type_builder("schema")
+        .with_fields(fields)
+        .build()
+        .unwrap();
 
-    let row_group_reader = reader.get_row_group(num_row_groups - 1)?;
-    let row_iter = row_group_reader.get_row_iter(None)?;
-    row_iter.last().transpose().map_err(Into::into)
+    let iter = reader.get_row_iter(Some(projection))?.map(|r| {
+        let mut hash = None;
+        let mut slot = None;
+        let mut number = None;
+        for column in r?.into_columns() {
+            match column {
+                (name, Field::Str(s)) if name == "hash" => {
+                    hash = Some(s);
+                }
+                (name, Field::Int(n)) if name == "number" => {
+                    number = Some(n as u64);
+                }
+                (name, Field::Long(n)) if name == "slot" => {
+                    slot = Some(n as u64);
+                }
+                _ => {}
+            }
+        }
+        Ok(BlockSummary {
+            hash: hash.ok_or(anyhow::anyhow!("No hash of block found"))?,
+            number: slot
+                .or(number)
+                .ok_or(anyhow::anyhow!("No number of block found"))?,
+            slot,
+        })
+    });
+    Ok(iter)
 }

--- a/crates/network-scheduler/src/parquet.rs
+++ b/crates/network-scheduler/src/parquet.rs
@@ -1,0 +1,47 @@
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::record::{Field, Row};
+use sqd_messages::assignments;
+use std::fs::File;
+
+pub fn read_chunk_summary(blocks_file: File) -> anyhow::Result<assignments::ChunkSummary> {
+    let Some(last_row) = read_last_row(blocks_file)? else {
+        anyhow::bail!("Empty blocks file");
+    };
+    let mut hash = None;
+    let mut slot = None;
+    let mut number = None;
+    for column in last_row.into_columns() {
+        match column {
+            (name, Field::Str(s)) if name == "hash" => {
+                hash = Some(s);
+            }
+            (name, Field::Int(n)) if name == "number" => {
+                number = Some(n as u64);
+            }
+            (name, Field::Long(n)) if name == "slot" => {
+                slot = Some(n as u64);
+            }
+            _ => {}
+        }
+    }
+    Ok(assignments::ChunkSummary {
+        last_block_hash: hash.ok_or(anyhow::anyhow!("No hash of last block found"))?,
+        last_block_number: slot
+            .or(number)
+            .ok_or(anyhow::anyhow!("No number of last block found",))?,
+    })
+}
+
+fn read_last_row(parquet: File) -> anyhow::Result<Option<Row>> {
+    let reader = SerializedFileReader::new(parquet)?;
+
+    let metadata = reader.metadata();
+    let num_row_groups = metadata.num_row_groups();
+    if num_row_groups == 0 {
+        return Ok(None);
+    }
+
+    let row_group_reader = reader.get_row_group(num_row_groups - 1)?;
+    let row_iter = row_group_reader.get_row_iter(None)?;
+    row_iter.last().transpose().map_err(Into::into)
+}

--- a/crates/network-scheduler/src/server.rs
+++ b/crates/network-scheduler/src/server.rs
@@ -292,6 +292,7 @@ fn build_assignment(
                 base_url: format!("{download_url}/{chunk_str}"),
                 files,
                 size_bytes,
+                summary: chunk.summary,
             };
 
             assignment.add_chunk(chunk, dataset_id, download_url);

--- a/crates/network-scheduler/src/storage.rs
+++ b/crates/network-scheduler/src/storage.rs
@@ -143,7 +143,7 @@ impl DatasetStorage {
         if let Some(last_chunk) = chunks.last_mut() {
             self.populate_with_summary(last_chunk)
                 .await
-                .context("couldn't download chunk summary")?;
+                .context(format!("couldn't download chunk summary for {}", last_chunk))?;
         }
 
         self.last_key = Some(last_key);

--- a/crates/network-scheduler/src/storage.rs
+++ b/crates/network-scheduler/src/storage.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::types::Object;
@@ -12,6 +13,7 @@ use flate2::Compression;
 use itertools::Itertools;
 use nonempty::NonEmpty;
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncSeekExt;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::Mutex;
 
@@ -117,7 +119,7 @@ impl DatasetStorage {
             Some(objects) => objects,
         };
         let last_key = objects.last().key();
-        let chunks = objects
+        let mut chunks = objects
             .into_iter()
             .chunk_by(|obj| obj.prefix.clone())
             .into_iter()
@@ -136,6 +138,12 @@ impl DatasetStorage {
                 );
             }
             next_block = Some(chunk.block_range.end + 1);
+        }
+
+        if let Some(last_chunk) = chunks.last_mut() {
+            self.populate_with_summary(last_chunk)
+                .await
+                .context("couldn't download chunk summary")?;
         }
 
         self.last_key = Some(last_key);
@@ -218,6 +226,38 @@ impl DatasetStorage {
             }
         }
         log::info!("Chunks stream ended");
+    }
+
+    async fn populate_with_summary(&self, data_chunk: &mut DataChunk) -> anyhow::Result<()> {
+        let key = format!("{}/blocks.parquet", data_chunk.chunk_str);
+        let temp_file = tempfile::tempfile()?;
+        let mut tokio_file = tokio::fs::File::from_std(temp_file);
+        self.download_object(&key, &mut tokio_file).await?;
+
+        tokio_file.rewind().await?;
+        let temp_file = tokio_file.into_std().await;
+        let summary =
+            tokio::task::spawn_blocking(move || crate::parquet::read_chunk_summary(temp_file))
+                .await??;
+
+        log::debug!("Adding summary to {}/{}: {:?}", self.bucket, key, summary);
+        data_chunk.summary = Some(summary);
+        Ok(())
+    }
+
+    async fn download_object(&self, key: &str, file: &mut tokio::fs::File) -> anyhow::Result<()> {
+        log::debug!("Downloading object {}/{} to extract summary", self.bucket, key);
+        let response = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await?;
+        let mut stream = response.body.into_async_read();
+        tokio::io::copy(&mut stream, file).await?;
+        log::debug!("Downloaded object {}/{}", self.bucket, key);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Populating the last chunk of the dataset with the last blocks' hash and number. This information will be used by the portal's `/head` endpoints. Block number is temporarily used because for Solana it differs from what is encoded in the chunk ID.

Implementation:\
Every time the chunk listing procedure hits the end of the storage, the `blocks.parquet` from the last discovered chunk is downloaded to a temporary file on disk and the fields from the last block are read from it via `parquet::file::reader` API.
The stored summaries from previous chunks are not cleaned up — in the future we will want to populate them for all chunks.