### PR TITLE
[fix_pings_without_assignment] don't fail when assignment id is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,7 +4617,7 @@ dependencies = [
 
 [[package]]
 name = "pings-collector"
-version = "2.4.0"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/collector-utils/src/storage.rs
+++ b/crates/collector-utils/src/storage.rs
@@ -271,14 +271,19 @@ pub struct PingRow {
 
 impl PingRow {
     pub fn new(heartbeat: Heartbeat, worker_id: String) -> Result<Self, &'static str> {
+        let assignment_timestamp = if heartbeat.assignment_id.is_empty() {
+            Ok(0)
+        } else {
+            parse_assignment_id(&heartbeat.assignment_id)
+        };
+
         Ok(Self {
             stored_bytes: heartbeat.stored_bytes(),
             worker_id,
             version: heartbeat.version,
             timestamp: timestamp_now_ms(),
             missing_chunks: heartbeat.missing_chunks.map_or(0, |b| b.ones),
-            assignment_timestamp: parse_assignment_id(&heartbeat.assignment_id)
-                .or(Err("cannot parse assignment_id"))?,
+            assignment_timestamp: assignment_timestamp.or(Err("cannot parse assignment_id"))?,
         })
     }
 }
@@ -574,5 +579,34 @@ mod tests {
         let res = PingRow::new(ping.clone(), worker_id.to_string());
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), "cannot parse assignment_id");
+    }
+
+    #[tokio::test]
+    async fn test_storage_assignment_id_empty() {
+        let worker_keypair = Keypair::from_protobuf_encoding(&[
+            8, 1, 18, 64, 212, 50, 184, 182, 239, 153, 10, 166, 254, 122, 105, 16, 51, 223, 126,
+            105, 10, 134, 204, 224, 42, 135, 92, 76, 32, 60, 197, 56, 128, 22, 131, 84, 233, 166,
+            242, 11, 16, 14, 160, 254, 4, 185, 170, 32, 157, 3, 144, 53, 230, 39, 150, 221, 142, 2,
+            37, 101, 100, 63, 24, 116, 110, 6, 156, 78,
+        ])
+        .unwrap();
+
+        let worker_id = PeerId::from_public_key(&worker_keypair.public());
+
+        let assignment_id = "";
+        let ping = Heartbeat {
+            version: "1.0.0".to_string(),
+            stored_bytes: Some(1024),
+            assignment_id: assignment_id.to_string(),
+            missing_chunks: Some(BitString {
+                data: vec![1, 0, 1, 0, 1, 0],
+                size: 6,
+                ones: 3,
+            }),
+        };
+
+        let res = PingRow::new(ping.clone(), worker_id.to_string());
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().assignment_timestamp, 0);
     }
 }

--- a/crates/pings-collector/Cargo.toml
+++ b/crates/pings-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pings-collector"
-version = "2.4.1"
+version = "2.4.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Fix: pings should not be rejected with empty assignment_id