### PR TITLE
Add API key id auth header

### DIFF
--- a/crates/router/src/auth/cache.rs
+++ b/crates/router/src/auth/cache.rs
@@ -5,7 +5,10 @@ use super::clock::{Clock, SystemClock};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KeyState {
-    Exists { user_id: String },
+    Exists {
+        user_id: String,
+        api_key_id: String,
+    },
     Deleted,
     /// Network API was unreachable on the most recent attempt for this key.
     /// Cached briefly so the singleflight queue can drain without each
@@ -78,7 +81,13 @@ impl KeyCache {
         }
     }
 
-    pub fn put_exists(&self, token: String, user_id: String, expires_at: Option<Instant>) {
+    pub fn put_exists(
+        &self,
+        token: String,
+        user_id: String,
+        api_key_id: String,
+        expires_at: Option<Instant>,
+    ) {
         let now = self.clock.now();
         if let Some(exp) = expires_at {
             if exp <= now {
@@ -92,7 +101,10 @@ impl KeyCache {
             None => default_deadline,
         };
         let entry = Entry {
-            state: KeyState::Exists { user_id },
+            state: KeyState::Exists {
+                user_id,
+                api_key_id,
+            },
             deadline,
         };
         self.inner.insert(token, entry);
@@ -136,23 +148,28 @@ mod tests {
         (cache, clock)
     }
 
-    fn exists(user: &str) -> KeyState {
+    fn exists(user: &str, api_key: &str) -> KeyState {
         KeyState::Exists {
             user_id: user.into(),
+            api_key_id: api_key.into(),
         }
     }
 
     #[test]
     fn get_undefined_returns_none() {
         let (c, _) = cache();
-        assert_eq!(c.get("unknown"), None, "UNDEFINED must be None, not Deleted");
+        assert_eq!(
+            c.get("unknown"),
+            None,
+            "UNDEFINED must be None, not Deleted"
+        );
     }
 
     #[test]
     fn put_exists_then_get() {
         let (c, _) = cache();
-        c.put_exists("tok".into(), "u1".into(), None);
-        assert_eq!(c.get("tok"), Some(exists("u1")));
+        c.put_exists("tok".into(), "u1".into(), "key1".into(), None);
+        assert_eq!(c.get("tok"), Some(exists("u1", "key1")));
     }
 
     #[test]
@@ -165,9 +182,9 @@ mod tests {
     #[test]
     fn exists_default_ttl_60s() {
         let (c, clock) = cache();
-        c.put_exists("tok".into(), "u".into(), None);
+        c.put_exists("tok".into(), "u".into(), "key".into(), None);
         clock.advance(Duration::from_secs(59));
-        assert_eq!(c.get("tok"), Some(exists("u")));
+        assert_eq!(c.get("tok"), Some(exists("u", "key")));
         clock.advance(Duration::from_secs(2));
         assert_eq!(c.get("tok"), None);
     }
@@ -186,9 +203,9 @@ mod tests {
     fn expires_at_clamped_inside_window() {
         let (c, clock) = cache();
         let exp = clock.now() + Duration::from_secs(30);
-        c.put_exists("tok".into(), "u".into(), Some(exp));
+        c.put_exists("tok".into(), "u".into(), "key".into(), Some(exp));
         clock.advance(Duration::from_secs(29));
-        assert_eq!(c.get("tok"), Some(exists("u")));
+        assert_eq!(c.get("tok"), Some(exists("u", "key")));
         clock.advance(Duration::from_secs(2));
         assert_eq!(c.get("tok"), None, "clamp should expire at 30s, not 60s");
     }
@@ -197,7 +214,7 @@ mod tests {
     fn expires_at_already_expired_stores_deleted() {
         let (c, clock) = cache();
         let exp = clock.now() - Duration::from_secs(1);
-        c.put_exists("tok".into(), "u".into(), Some(exp));
+        c.put_exists("tok".into(), "u".into(), "key".into(), Some(exp));
         assert_eq!(
             c.get("tok"),
             Some(KeyState::Deleted),
@@ -213,7 +230,7 @@ mod tests {
     fn undefined_ne_deleted_regression() {
         let (c, _) = cache();
         assert_eq!(c.get("tok"), None);
-        c.put_exists("tok".into(), "u".into(), None);
+        c.put_exists("tok".into(), "u".into(), "key".into(), None);
         let g = c.get("tok");
         assert!(matches!(g, Some(KeyState::Exists { .. })));
         assert_ne!(g, Some(KeyState::Deleted));
@@ -225,7 +242,7 @@ mod tests {
         let clock = TestClock::new();
         let cache = KeyCache::with_clock(100, clock.clone());
         for i in 0..1_000 {
-            cache.put_exists(format!("tok{i}"), "u".into(), None);
+            cache.put_exists(format!("tok{i}"), "u".into(), "key".into(), None);
         }
         let count = cache.entry_count();
         assert!(

--- a/crates/router/src/auth/client.rs
+++ b/crates/router/src/auth/client.rs
@@ -19,6 +19,7 @@ pub enum ValidateResult {
     /// `TTL_EXISTS` (60s) cache TTL.
     Exists {
         user_id: String,
+        api_key_id: String,
         expires_at: Option<Instant>,
     },
     Deleted,
@@ -28,6 +29,8 @@ pub enum ValidateResult {
 #[derive(Deserialize)]
 struct ValidateResponse {
     user_id: String,
+    #[serde(rename = "apiKeyId")]
+    api_key_id: String,
     /// Optional Unix timestamp (seconds) at which the server says this key
     /// stops being valid. Wired through to the cache so the entry expires
     /// at `min(now + TTL_EXISTS, expires_at)`. Server may omit it; the
@@ -39,7 +42,9 @@ struct ValidateResponse {
 #[derive(Clone, Copy)]
 enum OpenState {
     Closed,
-    Open { until: Instant },
+    Open {
+        until: Instant,
+    },
     /// A probe is in flight after the open window elapsed. No other
     /// requests are admitted until the probe records success or failure.
     HalfOpen,
@@ -265,6 +270,7 @@ impl NetworkApiClient {
                     });
                     ValidateResult::Exists {
                         user_id: body.user_id,
+                        api_key_id: body.api_key_id,
                         expires_at,
                     }
                 }

--- a/crates/router/src/auth/client.rs
+++ b/crates/router/src/auth/client.rs
@@ -29,7 +29,6 @@ pub enum ValidateResult {
 #[derive(Deserialize)]
 struct ValidateResponse {
     user_id: String,
-    #[serde(rename = "apiKeyId")]
     api_key_id: String,
     /// Optional Unix timestamp (seconds) at which the server says this key
     /// stops being valid. Wired through to the cache so the entry expires

--- a/crates/router/src/auth/client/tests.rs
+++ b/crates/router/src/auth/client/tests.rs
@@ -26,7 +26,9 @@ async fn validate_200_returns_exists() {
     let s = server().await;
     Mock::given(method("POST"))
         .and(path("/internal/validate"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1"})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "apiKeyId": "key1"})),
+        )
         .mount(&s)
         .await;
     let c = client(&s, TestClock::new());
@@ -34,6 +36,7 @@ async fn validate_200_returns_exists() {
         c.validate("sqd_data_abc_xyz").await,
         ValidateResult::Exists {
             user_id: "u1".into(),
+            api_key_id: "key1".into(),
             expires_at: None,
         }
     );
@@ -57,7 +60,7 @@ async fn validate_200_propagates_expires_at() {
         .and(path("/internal/validate"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_json(json!({"user_id": "u1", "expires_at": exp})),
+                .set_body_json(json!({"user_id": "u1", "apiKeyId": "key1", "expires_at": exp})),
         )
         .mount(&s)
         .await;
@@ -65,9 +68,11 @@ async fn validate_200_propagates_expires_at() {
     match c.validate("sqd_data_abc_xyz").await {
         ValidateResult::Exists {
             user_id,
+            api_key_id,
             expires_at: Some(_),
         } => {
             assert_eq!(user_id, "u1");
+            assert_eq!(api_key_id, "key1");
             // Specific value depends on TestClock starting reference;
             // the existence of Some(_) is what we assert here, plus the
             // cache test below which exercises the clamping behaviour.
@@ -90,7 +95,7 @@ async fn validate_200_past_expires_at_returns_now() {
         .and(path("/internal/validate"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_json(json!({"user_id": "u1", "expires_at": past})),
+                .set_body_json(json!({"user_id": "u1", "apiKeyId": "key1", "expires_at": past})),
         )
         .mount(&s)
         .await;
@@ -213,7 +218,10 @@ async fn breaker_opens_after_50_consecutive_errors() {
     // 51st must short-circuit (no HTTP call).
     assert_eq!(c.validate("sqd_data_x_y").await, ValidateResult::FailOpen);
     let received_after = s.received_requests().await.unwrap().len();
-    assert_eq!(received_after, 50, "breaker must short-circuit the 51st call");
+    assert_eq!(
+        received_after, 50,
+        "breaker must short-circuit the 51st call"
+    );
 }
 
 #[tokio::test]
@@ -245,7 +253,9 @@ async fn breaker_resets_on_success() {
         .mount(&s)
         .await;
     Mock::given(method("POST"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"user_id": "u"})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u", "apiKeyId": "key"})),
+        )
         .mount(&s)
         .await;
     let clock = TestClock::new();
@@ -321,7 +331,9 @@ async fn breaker_half_open_admits_exactly_one_probe() {
     let c = Arc::new(c);
     for _ in 0..10 {
         let c = c.clone();
-        handles.push(tokio::spawn(async move { c.validate("sqd_data_x_y").await }));
+        handles.push(tokio::spawn(
+            async move { c.validate("sqd_data_x_y").await },
+        ));
     }
     for h in handles {
         let _ = h.await;
@@ -342,8 +354,16 @@ fn build_url_preserves_subpath_with_trailing_slash() {
         Some(Url::parse("http://auth.example.com/api/v2/").unwrap()),
         TestClock::new(),
     );
-    let joined = c.base_url.as_ref().unwrap().join("internal/validate").unwrap();
-    assert_eq!(joined.as_str(), "http://auth.example.com/api/v2/internal/validate");
+    let joined = c
+        .base_url
+        .as_ref()
+        .unwrap()
+        .join("internal/validate")
+        .unwrap();
+    assert_eq!(
+        joined.as_str(),
+        "http://auth.example.com/api/v2/internal/validate"
+    );
 }
 
 /// Without a trailing slash on the input, the client should still
@@ -354,8 +374,16 @@ fn build_url_preserves_subpath_without_trailing_slash() {
         Some(Url::parse("http://auth.example.com/api/v2").unwrap()),
         TestClock::new(),
     );
-    let joined = c.base_url.as_ref().unwrap().join("internal/validate").unwrap();
-    assert_eq!(joined.as_str(), "http://auth.example.com/api/v2/internal/validate");
+    let joined = c
+        .base_url
+        .as_ref()
+        .unwrap()
+        .join("internal/validate")
+        .unwrap();
+    assert_eq!(
+        joined.as_str(),
+        "http://auth.example.com/api/v2/internal/validate"
+    );
 }
 
 /// Plain root-only base still resolves correctly.
@@ -365,7 +393,12 @@ fn build_url_root_base() {
         Some(Url::parse("http://auth.example.com").unwrap()),
         TestClock::new(),
     );
-    let joined = c.base_url.as_ref().unwrap().join("internal/validate").unwrap();
+    let joined = c
+        .base_url
+        .as_ref()
+        .unwrap()
+        .join("internal/validate")
+        .unwrap();
     assert_eq!(joined.as_str(), "http://auth.example.com/internal/validate");
 }
 
@@ -376,7 +409,9 @@ async fn validate_calls_subpath_route() {
     let s = server().await;
     Mock::given(method("POST"))
         .and(path("/api/v2/internal/validate"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1"})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "apiKeyId": "key1"})),
+        )
         .mount(&s)
         .await;
     let c = NetworkApiClient::with_clock(
@@ -444,7 +479,9 @@ async fn validate_issues_a_real_send() {
     let s = server().await;
     Mock::given(method("POST"))
         .and(path("/internal/validate"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1"})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "apiKeyId": "key1"})),
+        )
         .mount(&s)
         .await;
     let c = client(&s, TestClock::new());
@@ -561,7 +598,9 @@ async fn request_body_is_token_only() {
     Mock::given(method("POST"))
         .and(path("/internal/validate"))
         .and(body_json(json!({"token": "sqd_data_abc_xyz"})))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"user_id": "u"})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u", "apiKeyId": "key"})),
+        )
         .mount(&s)
         .await;
     let c = client(&s, TestClock::new());

--- a/crates/router/src/auth/client/tests.rs
+++ b/crates/router/src/auth/client/tests.rs
@@ -27,7 +27,7 @@ async fn validate_200_returns_exists() {
     Mock::given(method("POST"))
         .and(path("/internal/validate"))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "apiKeyId": "key1"})),
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "api_key_id": "key1"})),
         )
         .mount(&s)
         .await;
@@ -60,7 +60,7 @@ async fn validate_200_propagates_expires_at() {
         .and(path("/internal/validate"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_json(json!({"user_id": "u1", "apiKeyId": "key1", "expires_at": exp})),
+                .set_body_json(json!({"user_id": "u1", "api_key_id": "key1", "expires_at": exp})),
         )
         .mount(&s)
         .await;
@@ -95,7 +95,7 @@ async fn validate_200_past_expires_at_returns_now() {
         .and(path("/internal/validate"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_json(json!({"user_id": "u1", "apiKeyId": "key1", "expires_at": past})),
+                .set_body_json(json!({"user_id": "u1", "api_key_id": "key1", "expires_at": past})),
         )
         .mount(&s)
         .await;
@@ -254,7 +254,7 @@ async fn breaker_resets_on_success() {
         .await;
     Mock::given(method("POST"))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u", "apiKeyId": "key"})),
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u", "api_key_id": "key"})),
         )
         .mount(&s)
         .await;
@@ -410,7 +410,7 @@ async fn validate_calls_subpath_route() {
     Mock::given(method("POST"))
         .and(path("/api/v2/internal/validate"))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "apiKeyId": "key1"})),
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "api_key_id": "key1"})),
         )
         .mount(&s)
         .await;
@@ -480,7 +480,7 @@ async fn validate_issues_a_real_send() {
     Mock::given(method("POST"))
         .and(path("/internal/validate"))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "apiKeyId": "key1"})),
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u1", "api_key_id": "key1"})),
         )
         .mount(&s)
         .await;
@@ -599,7 +599,7 @@ async fn request_body_is_token_only() {
         .and(path("/internal/validate"))
         .and(body_json(json!({"token": "sqd_data_abc_xyz"})))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u", "apiKeyId": "key"})),
+            ResponseTemplate::new(200).set_body_json(json!({"user_id": "u", "api_key_id": "key"})),
         )
         .mount(&s)
         .await;

--- a/crates/router/src/auth/middleware.rs
+++ b/crates/router/src/auth/middleware.rs
@@ -18,6 +18,7 @@ use crate::metrics::{
 
 const TOKEN_PREFIX: &str = "sqd_data_";
 const USER_ID_HEADER: &str = "x-sqd-user-id";
+const API_KEY_ID_HEADER: &str = "x-sqd-api-key-id";
 
 /// Fixed user_id for IP-allowlist bypass requests. Single label keeps the
 /// top-keys sketch (REQUESTS_BY_KEY) bounded — see `decide` step 3.
@@ -37,11 +38,14 @@ const INTERNAL_BYPASS_USER_ID: &str = "internal";
 const ORIGINAL_FORWARDED_FOR: &str = "X-Original-Forwarded-For";
 
 /// Value attached to the request via Extensions on a successful auth pass.
-/// Downstream handlers can read `user_id` for audit attribution.
+/// Downstream handlers can read validated key identity for audit attribution.
+/// IP-allowlist bypass uses the fixed `internal` identity.
 #[derive(Clone, Debug)]
 pub struct AuthContext {
     #[allow(dead_code)]
-    pub user_id: String,
+    pub user_id: Option<String>,
+    #[allow(dead_code)]
+    pub api_key_id: Option<String>,
 }
 
 #[derive(Debug)]
@@ -102,21 +106,37 @@ where
         // Sketch update + label add/remove are performed under the
         // top-keys lock so that a concurrent eviction can't be silently
         // undone by a stale `with_label_values` call from another task.
-        // We label by user_id (the only token-derived value safe to
-        // expose: it identifies the tenant, not the secret material).
-        state.top_keys.observe_into(&ctx.user_id, &REQUESTS_BY_KEY);
+        // We label validated requests by user_id (the only token-derived value
+        // safe to expose: it identifies the tenant, not the secret material).
+        // IP-bypass requests use the bounded synthetic `internal` identity.
+        let metric_user_id = ctx.user_id.as_deref().unwrap_or(INTERNAL_BYPASS_USER_ID);
+        state
+            .top_keys
+            .observe_into(metric_user_id, &REQUESTS_BY_KEY);
         req.extensions_mut().insert(ctx.clone());
     }
 
     if allowed {
         let mut resp = next.run(req).await;
         if let Outcome::Ok(ctx) = &outcome {
-            match HeaderValue::from_str(&ctx.user_id) {
-                Ok(value) => {
-                    resp.headers_mut().insert(USER_ID_HEADER, value);
+            if let Some(user_id) = &ctx.user_id {
+                match HeaderValue::from_str(user_id) {
+                    Ok(value) => {
+                        resp.headers_mut().insert(USER_ID_HEADER, value);
+                    }
+                    Err(_) => {
+                        warn!("validated user_id cannot be encoded as response header");
+                    }
                 }
-                Err(_) => {
-                    warn!("validated user_id cannot be encoded as response header");
+            }
+            if let Some(api_key_id) = &ctx.api_key_id {
+                match HeaderValue::from_str(api_key_id) {
+                    Ok(value) => {
+                        resp.headers_mut().insert(API_KEY_ID_HEADER, value);
+                    }
+                    Err(_) => {
+                        warn!("validated api_key_id cannot be encoded as response header");
+                    }
                 }
             }
         }
@@ -191,7 +211,8 @@ async fn decide<B>(state: &AuthState, req: &mut Request<B>) -> (Outcome, Option<
             if state.internal_allowlist.iter().any(|net| net.contains(&ip)) {
                 return (
                     Outcome::Ok(AuthContext {
-                        user_id: INTERNAL_BYPASS_USER_ID.to_string(),
+                        user_id: Some(INTERNAL_BYPASS_USER_ID.to_string()),
+                        api_key_id: Some(INTERNAL_BYPASS_USER_ID.to_string()),
                     }),
                     Some(ip),
                 );
@@ -231,12 +252,19 @@ async fn decide<B>(state: &AuthState, req: &mut Request<B>) -> (Outcome, Option<
     let outcome = match state.client.validate(token).await {
         ValidateResult::Exists {
             user_id,
+            api_key_id,
             expires_at,
         } => {
-            state
-                .cache
-                .put_exists(token.to_string(), user_id.clone(), expires_at);
-            Outcome::Ok(AuthContext { user_id })
+            state.cache.put_exists(
+                token.to_string(),
+                user_id.clone(),
+                api_key_id.clone(),
+                expires_at,
+            );
+            Outcome::Ok(AuthContext {
+                user_id: Some(user_id),
+                api_key_id: Some(api_key_id),
+            })
         }
         ValidateResult::Deleted => {
             state.cache.put_deleted(token.to_string());
@@ -254,9 +282,15 @@ async fn decide<B>(state: &AuthState, req: &mut Request<B>) -> (Outcome, Option<
 /// Cache lookup translated to an Outcome, or `None` if the slot is UNDEFINED.
 fn lookup(state: &AuthState, token: &str) -> Option<Outcome> {
     match state.cache.get(token)? {
-        KeyState::Exists { user_id } => {
+        KeyState::Exists {
+            user_id,
+            api_key_id,
+        } => {
             CACHE_HIT_TOTAL.with_label_values(&["exists"]).inc();
-            Some(Outcome::Ok(AuthContext { user_id }))
+            Some(Outcome::Ok(AuthContext {
+                user_id: Some(user_id),
+                api_key_id: Some(api_key_id),
+            }))
         }
         KeyState::Deleted => {
             CACHE_HIT_TOTAL.with_label_values(&["deleted"]).inc();

--- a/crates/router/src/auth/middleware.rs
+++ b/crates/router/src/auth/middleware.rs
@@ -43,9 +43,9 @@ const ORIGINAL_FORWARDED_FOR: &str = "X-Original-Forwarded-For";
 #[derive(Clone, Debug)]
 pub struct AuthContext {
     #[allow(dead_code)]
-    pub user_id: Option<String>,
+    pub user_id: String,
     #[allow(dead_code)]
-    pub api_key_id: Option<String>,
+    pub api_key_id: String,
 }
 
 #[derive(Debug)]
@@ -109,34 +109,27 @@ where
         // We label validated requests by user_id (the only token-derived value
         // safe to expose: it identifies the tenant, not the secret material).
         // IP-bypass requests use the bounded synthetic `internal` identity.
-        let metric_user_id = ctx.user_id.as_deref().unwrap_or(INTERNAL_BYPASS_USER_ID);
-        state
-            .top_keys
-            .observe_into(metric_user_id, &REQUESTS_BY_KEY);
+        state.top_keys.observe_into(&ctx.user_id, &REQUESTS_BY_KEY);
         req.extensions_mut().insert(ctx.clone());
     }
 
     if allowed {
         let mut resp = next.run(req).await;
         if let Outcome::Ok(ctx) = &outcome {
-            if let Some(user_id) = &ctx.user_id {
-                match HeaderValue::from_str(user_id) {
-                    Ok(value) => {
-                        resp.headers_mut().insert(USER_ID_HEADER, value);
-                    }
-                    Err(_) => {
-                        warn!("validated user_id cannot be encoded as response header");
-                    }
+            match HeaderValue::from_str(&ctx.user_id) {
+                Ok(value) => {
+                    resp.headers_mut().insert(USER_ID_HEADER, value);
+                }
+                Err(_) => {
+                    warn!("validated user_id cannot be encoded as response header");
                 }
             }
-            if let Some(api_key_id) = &ctx.api_key_id {
-                match HeaderValue::from_str(api_key_id) {
-                    Ok(value) => {
-                        resp.headers_mut().insert(API_KEY_ID_HEADER, value);
-                    }
-                    Err(_) => {
-                        warn!("validated api_key_id cannot be encoded as response header");
-                    }
+            match HeaderValue::from_str(&ctx.api_key_id) {
+                Ok(value) => {
+                    resp.headers_mut().insert(API_KEY_ID_HEADER, value);
+                }
+                Err(_) => {
+                    warn!("validated api_key_id cannot be encoded as response header");
                 }
             }
         }
@@ -211,8 +204,8 @@ async fn decide<B>(state: &AuthState, req: &mut Request<B>) -> (Outcome, Option<
             if state.internal_allowlist.iter().any(|net| net.contains(&ip)) {
                 return (
                     Outcome::Ok(AuthContext {
-                        user_id: Some(INTERNAL_BYPASS_USER_ID.to_string()),
-                        api_key_id: Some(INTERNAL_BYPASS_USER_ID.to_string()),
+                        user_id: INTERNAL_BYPASS_USER_ID.to_string(),
+                        api_key_id: INTERNAL_BYPASS_USER_ID.to_string(),
                     }),
                     Some(ip),
                 );
@@ -262,8 +255,8 @@ async fn decide<B>(state: &AuthState, req: &mut Request<B>) -> (Outcome, Option<
                 expires_at,
             );
             Outcome::Ok(AuthContext {
-                user_id: Some(user_id),
-                api_key_id: Some(api_key_id),
+                user_id,
+                api_key_id,
             })
         }
         ValidateResult::Deleted => {
@@ -288,8 +281,8 @@ fn lookup(state: &AuthState, token: &str) -> Option<Outcome> {
         } => {
             CACHE_HIT_TOTAL.with_label_values(&["exists"]).inc();
             Some(Outcome::Ok(AuthContext {
-                user_id: Some(user_id),
-                api_key_id: Some(api_key_id),
+                user_id,
+                api_key_id,
             }))
         }
         KeyState::Deleted => {

--- a/crates/router/src/auth/middleware/tests.rs
+++ b/crates/router/src/auth/middleware/tests.rs
@@ -27,7 +27,12 @@ async fn metrics_lock() -> MutexGuard<'static, ()> {
 
 async fn downstream_handler(req: Request<Body>) -> Response {
     match req.extensions().get::<AuthContext>() {
-        Some(ctx) => format!("ok:{}", ctx.user_id).into_response(),
+        Some(ctx) => format!(
+            "ok:{}:{}",
+            ctx.user_id.as_deref().unwrap_or("null"),
+            ctx.api_key_id.as_deref().unwrap_or("null")
+        )
+        .into_response(),
         None => "ok:no-ctx".into_response(),
     }
 }
@@ -63,12 +68,29 @@ fn assert_no_user_id_header(resp: &Response) {
     );
 }
 
+fn assert_api_key_id_header(resp: &Response, expected: &str) {
+    assert_eq!(
+        resp.headers()
+            .get(API_KEY_ID_HEADER)
+            .and_then(|value| value.to_str().ok()),
+        Some(expected)
+    );
+}
+
+fn assert_no_api_key_id_header(resp: &Response) {
+    assert!(
+        resp.headers().get(API_KEY_ID_HEADER).is_none(),
+        "{API_KEY_ID_HEADER} must not be present"
+    );
+}
+
 fn good_validate_mock(user_id: &str) -> Mock {
     Mock::given(method("POST"))
         .and(path("/internal/validate"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!({"user_id": user_id})),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "user_id": user_id,
+            "apiKeyId": "key1"
+        })))
 }
 
 fn nf_validate_mock() -> Mock {
@@ -114,7 +136,8 @@ async fn bearer_header_extracts_key() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert_user_id_header(&resp, "u1");
-    assert_eq!(body_string(resp).await, "ok:u1");
+    assert_api_key_id_header(&resp, "key1");
+    assert_eq!(body_string(resp).await, "ok:u1:key1");
     assert_eq!(count_auth("ok") - before_ok, 1);
 }
 
@@ -138,6 +161,7 @@ async fn no_token_header_fallback() {
     // No Authorization header -> Missing -> 403 (enforce=true).
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_no_user_id_header(&resp);
+    assert_no_api_key_id_header(&resp);
     // Wiremock must not have been hit.
     assert_eq!(s.received_requests().await.unwrap().len(), 0);
 }
@@ -377,6 +401,7 @@ async fn cached_deleted_denies_during_outage() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_no_user_id_header(&resp);
+    assert_no_api_key_id_header(&resp);
 }
 
 #[tokio::test]
@@ -418,6 +443,7 @@ async fn breaker_open_passes_through_without_dial() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert_no_user_id_header(&resp);
+    assert_no_api_key_id_header(&resp);
     assert_eq!(
         s.received_requests().await.unwrap().len(),
         50,
@@ -443,7 +469,8 @@ async fn key_id_in_request_extensions() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert_user_id_header(&resp, "user42");
-    assert_eq!(body_string(resp).await, "ok:user42");
+    assert_api_key_id_header(&resp, "key1");
+    assert_eq!(body_string(resp).await, "ok:user42:key1");
 }
 
 #[tokio::test]
@@ -467,6 +494,7 @@ async fn cache_miss_then_hit() {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         assert_user_id_header(&resp, "u");
+        assert_api_key_id_header(&resp, "key1");
     }
     assert_eq!(
         s.received_requests().await.unwrap().len(),
@@ -534,7 +562,7 @@ async fn concurrent_miss_flood_coalesces_to_one_call() {
         .and(path("/internal/validate"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"user_id": "u1"}))
+                .set_body_json(serde_json::json!({"user_id": "u1", "apiKeyId": "key1"}))
                 .set_delay(Duration::from_millis(50)),
         )
         .mount(&s)
@@ -841,7 +869,8 @@ async fn bypass_xoff_real_client_in_allowlist() {
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert_user_id_header(&resp, INTERNAL_BYPASS_USER_ID);
-    assert_eq!(body_string(resp).await, "ok:internal");
+    assert_api_key_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_eq!(body_string(resp).await, "ok:internal:internal");
     // Bypass must NOT touch the Network API.
     assert_eq!(s.received_requests().await.unwrap().len(), 0);
 }
@@ -927,7 +956,9 @@ async fn bypass_clusterip_peer_in_allowlist() {
     let resp = app(state).oneshot(request).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(body_string(resp).await, "ok:internal");
+    assert_user_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_api_key_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_eq!(body_string(resp).await, "ok:internal:internal");
 }
 
 // ConnectInfo present but peer NOT in allowlist -> standard auth.
@@ -1026,7 +1057,9 @@ async fn bypass_malformed_xoff_falls_back_to_connect_info() {
     // Malformed entries skipped; chain yields no valid IP; fall back to
     // peer (ConnectInfo) which IS in allowlist.
     assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(body_string(resp).await, "ok:internal");
+    assert_user_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_api_key_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_eq!(body_string(resp).await, "ok:internal:internal");
 }
 
 // Chain consisting entirely of trusted IPs -> no real-client extraction
@@ -1083,7 +1116,9 @@ async fn bypass_multiple_allowlist_cidrs() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(body_string(resp).await, "ok:internal");
+    assert_user_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_api_key_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_eq!(body_string(resp).await, "ok:internal:internal");
 }
 
 // Duplicate-Authorization rejection runs FIRST, even when the source IP
@@ -1147,7 +1182,8 @@ async fn bypass_takes_precedence_over_valid_bearer() {
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert_user_id_header(&resp, INTERNAL_BYPASS_USER_ID);
-    assert_eq!(body_string(resp).await, "ok:internal");
+    assert_api_key_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_eq!(body_string(resp).await, "ok:internal:internal");
     // Network API must NOT have been called — we short-circuited on IP.
     assert_eq!(s.received_requests().await.unwrap().len(), 0);
 }
@@ -1602,5 +1638,7 @@ async fn canary_internal_allowlist_takes_precedence() {
     let resp = app(state).oneshot(request).await.unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(body_string(resp).await, "ok:internal");
+    assert_user_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_api_key_id_header(&resp, INTERNAL_BYPASS_USER_ID);
+    assert_eq!(body_string(resp).await, "ok:internal:internal");
 }

--- a/crates/router/src/auth/middleware/tests.rs
+++ b/crates/router/src/auth/middleware/tests.rs
@@ -84,7 +84,7 @@ fn good_validate_mock(user_id: &str) -> Mock {
         .and(path("/internal/validate"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "user_id": user_id,
-            "apiKeyId": "key1"
+            "api_key_id": "key1"
         })))
 }
 
@@ -557,7 +557,7 @@ async fn concurrent_miss_flood_coalesces_to_one_call() {
         .and(path("/internal/validate"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_json(serde_json::json!({"user_id": "u1", "apiKeyId": "key1"}))
+                .set_body_json(serde_json::json!({"user_id": "u1", "api_key_id": "key1"}))
                 .set_delay(Duration::from_millis(50)),
         )
         .mount(&s)

--- a/crates/router/src/auth/middleware/tests.rs
+++ b/crates/router/src/auth/middleware/tests.rs
@@ -27,12 +27,7 @@ async fn metrics_lock() -> MutexGuard<'static, ()> {
 
 async fn downstream_handler(req: Request<Body>) -> Response {
     match req.extensions().get::<AuthContext>() {
-        Some(ctx) => format!(
-            "ok:{}:{}",
-            ctx.user_id.as_deref().unwrap_or("null"),
-            ctx.api_key_id.as_deref().unwrap_or("null")
-        )
-        .into_response(),
+        Some(ctx) => format!("ok:{}:{}", ctx.user_id, ctx.api_key_id).into_response(),
         None => "ok:no-ctx".into_response(),
     }
 }


### PR DESCRIPTION
## Summary
- Parse required `apiKeyId` from validate API success responses.
- Carry API key id through auth cache and request context.
- Emit `x-sqd-api-key-id` for validated API key requests.
- Represent IP-allowlist bypass identity as null/absent for both user id and API key id.

## Tests
- `cargo test -p router auth::cache::tests`
- `cargo test -p router auth::client::tests`
- `cargo test -p router auth::middleware::tests`