### PR TITLE
Validate disabled auth tokens for identity headers

### DIFF
--- a/crates/router/src/auth/middleware.rs
+++ b/crates/router/src/auth/middleware.rs
@@ -54,10 +54,6 @@ enum Outcome {
     Missing,
     Invalid,
     FailOpen,
-    /// Kill switch active (`DISABLE_V2_AUTH=true`). Counted under its own
-    /// label so the dashboard makes it obvious that auth is bypassed
-    /// globally, not silently absorbed into `ok`.
-    Disabled,
 }
 
 impl Outcome {
@@ -67,7 +63,6 @@ impl Outcome {
             Outcome::Missing => "missing",
             Outcome::Invalid => "invalid",
             Outcome::FailOpen => "fail_open",
-            Outcome::Disabled => "disabled",
         }
     }
 }
@@ -82,25 +77,16 @@ where
         .cloned()
         .expect("AuthState extension is required by auth middleware");
 
-    // Kill switch — short-circuits BEFORE the latency timer / decide so the
-    // disabled path is genuinely ~zero work. We still emit one metric
-    // sample so dashboards can see the switch is engaged.
-    if state.disabled {
-        AUTH_TOTAL
-            .with_label_values(&[Outcome::Disabled.label()])
-            .inc();
-        return next.run(req).await;
-    }
-
     let timer = AUTH_LATENCY_SECONDS.start_timer();
     let (outcome, real_ip) = decide(&state, &mut req).await;
     AUTH_TOTAL.with_label_values(&[outcome.label()]).inc();
     timer.observe_duration();
 
-    let allowed = match &outcome {
-        Outcome::Ok(_) | Outcome::FailOpen | Outcome::Disabled => true,
-        Outcome::Missing | Outcome::Invalid => !should_enforce(&state, real_ip),
-    };
+    let allowed = state.disabled
+        || match &outcome {
+            Outcome::Ok(_) | Outcome::FailOpen => true,
+            Outcome::Missing | Outcome::Invalid => !should_enforce(&state, real_ip),
+        };
 
     if let Outcome::Ok(ctx) = &outcome {
         // Sketch update + label add/remove are performed under the

--- a/crates/router/src/auth/middleware/tests.rs
+++ b/crates/router/src/auth/middleware/tests.rs
@@ -1203,19 +1203,18 @@ async fn bypass_without_xoff_or_connect_info_falls_through() {
 
 // ─── DISABLE_V2_AUTH (kill switch) ──────────────────────────────────────
 //
-// `disabled=true` short-circuits at the very top of `auth()`: no decide,
-// no cache work, no Network API call. One metric sample under the
-// `disabled` label so the dashboard shows the switch is engaged.
+// `disabled=true` disables enforcement, not identity extraction. If an
+// Authorization bearer is present and the validate endpoint is configured,
+// the middleware still validates it so downstreams receive identity headers.
 
 fn all_ips_v() -> Vec<IpNet> {
     vec![netv("0.0.0.0/0"), netv("::/0")]
 }
 
 #[tokio::test]
-async fn disable_short_circuits_missing_token() {
+async fn disable_allows_missing_token() {
     let _g = metrics_lock().await;
     let s = MockServer::start().await;
-    // Validate API would 404 if we ever reached it; we shouldn't.
     nf_validate_mock().mount(&s).await;
 
     // Kill switch on; enforcement also globally on, but should be irrelevant.
@@ -1228,24 +1227,19 @@ async fn disable_short_circuits_missing_token() {
         vec![],
     );
 
-    let before = AUTH_TOTAL.with_label_values(&["disabled"]).get();
+    let before = count_auth("missing");
     let resp = app(state)
         .oneshot(req("/test").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    assert_eq!(
-        AUTH_TOTAL.with_label_values(&["disabled"]).get() - before,
-        1,
-        "kill switch must increment auth_total{{disabled}} exactly once"
-    );
-    // Network API must NOT be called.
+    assert_eq!(count_auth("missing") - before, 1);
     assert_eq!(s.received_requests().await.unwrap().len(), 0);
 }
 
 #[tokio::test]
-async fn disable_short_circuits_invalid_token() {
+async fn disable_allows_locally_invalid_token() {
     let _g = metrics_lock().await;
     let s = MockServer::start().await;
     nf_validate_mock().mount(&s).await;
@@ -1275,7 +1269,70 @@ async fn disable_short_circuits_invalid_token() {
 }
 
 #[tokio::test]
-async fn disable_short_circuits_duplicate_authorization() {
+async fn disable_populates_identity_headers_for_valid_token() {
+    let _g = metrics_lock().await;
+    let s = MockServer::start().await;
+    good_validate_mock("u1").mount(&s).await;
+
+    let state = AuthState::for_test_full(
+        Some(Url::parse(&s.uri()).unwrap()),
+        TestClock::new(),
+        true,
+        all_ips_v(),
+        vec![],
+        vec![],
+    );
+
+    let resp = app(state)
+        .oneshot(
+            req("/test")
+                .header(header::AUTHORIZATION, "Bearer sqd_data_abc_xyz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_user_id_header(&resp, "u1");
+    assert_api_key_id_header(&resp, "key1");
+    assert_eq!(body_string(resp).await, "ok:u1:key1");
+    assert_eq!(s.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn disable_allows_deleted_validate_response() {
+    let _g = metrics_lock().await;
+    let s = MockServer::start().await;
+    nf_validate_mock().mount(&s).await;
+    let state = AuthState::for_test_full(
+        Some(Url::parse(&s.uri()).unwrap()),
+        TestClock::new(),
+        true,
+        all_ips_v(),
+        vec![],
+        vec![],
+    );
+
+    let resp = app(state)
+        .oneshot(
+            req("/test")
+                .header(header::AUTHORIZATION, "Bearer sqd_data_abc_xyz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_no_user_id_header(&resp);
+    assert_no_api_key_id_header(&resp);
+    assert_eq!(body_string(resp).await, "ok:no-ctx");
+    assert_eq!(s.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn disable_allows_duplicate_authorization() {
     let _g = metrics_lock().await;
     let s = MockServer::start().await;
     nf_validate_mock().mount(&s).await;
@@ -1290,7 +1347,7 @@ async fn disable_short_circuits_duplicate_authorization() {
     );
 
     // Duplicate Authorization is normally a hard 403 (RFC 6750 §3.1).
-    // With the kill switch on, even that is suppressed — auth path is OFF.
+    // With the kill switch on, even that is allowed.
     let resp = app(state)
         .oneshot(
             req("/test")
@@ -1306,25 +1363,12 @@ async fn disable_short_circuits_duplicate_authorization() {
 }
 
 #[tokio::test]
-async fn disable_does_not_emit_decide_metrics() {
+async fn disable_without_validate_endpoint_passes_without_identity_headers() {
     let _g = metrics_lock().await;
-    let s = MockServer::start().await;
-    good_validate_mock("u1").mount(&s).await;
 
-    let state = AuthState::for_test_full(
-        Some(Url::parse(&s.uri()).unwrap()),
-        TestClock::new(),
-        true,
-        all_ips_v(),
-        vec![],
-        vec![],
-    );
+    let state = AuthState::for_test_full(None, TestClock::new(), true, all_ips_v(), vec![], vec![]);
 
-    let before_ok = count_auth("ok");
-    let before_missing = count_auth("missing");
-    let before_lat = AUTH_LATENCY_SECONDS.get_sample_count();
-
-    let _ = app(state)
+    let resp = app(state)
         .oneshot(
             req("/test")
                 .header(header::AUTHORIZATION, "Bearer sqd_data_abc_xyz")
@@ -1334,15 +1378,10 @@ async fn disable_does_not_emit_decide_metrics() {
         .await
         .unwrap();
 
-    // Kill switch path emits exactly the `disabled` counter — neither
-    // `ok` (which would imply a full decide), nor the latency histogram.
-    assert_eq!(count_auth("ok"), before_ok, "no ok metric on kill switch");
-    assert_eq!(count_auth("missing"), before_missing);
-    assert_eq!(
-        AUTH_LATENCY_SECONDS.get_sample_count(),
-        before_lat,
-        "kill switch must skip the latency timer entirely"
-    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_no_user_id_header(&resp);
+    assert_no_api_key_id_header(&resp);
+    assert_eq!(body_string(resp).await, "ok:no-ctx");
 }
 
 // ─── ENFORCE_V2_AUTH_FOR_IPS (canary by IP) ─────────────────────────────


### PR DESCRIPTION
## Summary
- Keep auth middleware on the normal validation path when `DISABLE_V2_AUTH` is enabled
- Treat disabled auth as "do not deny" while still populating `x-sqd-user-id` and `x-sqd-api-key-id` for valid bearer tokens
- Cover disabled-mode missing, invalid, deleted, duplicate, valid-token, and no-validate-endpoint behavior

## Testing
- `cargo test -p router auth::middleware::tests -- --nocapture`