### PR TITLE
Skip empty batches to avoid clickhouse panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "collector-utils"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3783,7 +3783,7 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "logs-collector"
-version = "2.1.7"
+version = "2.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4617,7 +4617,7 @@ dependencies = [
 
 [[package]]
 name = "pings-collector"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4676,7 +4676,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portal-logs-collector"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/collector-utils/Cargo.toml
+++ b/crates/collector-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collector-utils"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/collector-utils/src/storage.rs
+++ b/crates/collector-utils/src/storage.rs
@@ -382,6 +382,11 @@ impl Storage for ClickhouseStorage {
         query_logs: T,
     ) -> anyhow::Result<()> {
         log::debug!("Storing logs in clickhouse");
+        let mut query_logs = query_logs.peekable();
+        if query_logs.peek().is_none() {
+            log::debug!("No logs to store, skipping empty batch");
+            return Ok(());
+        }
         let mut insert = self.0.insert(&LOGS_TABLE)?;
         for row in query_logs {
             log::trace!("Storing query log {:?}", row);
@@ -396,6 +401,11 @@ impl Storage for ClickhouseStorage {
         pings: T,
     ) -> anyhow::Result<()> {
         log::debug!("Storing pings in clickhouse");
+        let mut pings = pings.peekable();
+        if pings.peek().is_none() {
+            log::debug!("No pings to store, skipping empty batch");
+            return Ok(());
+        }
         let mut insert = self.0.insert(&PINGS_TABLE)?;
         for row in pings {
             log::trace!("Storing ping {:?}", row);
@@ -427,6 +437,11 @@ impl Storage for ClickhouseStorage {
         portal_logs: T,
     ) -> anyhow::Result<()> {
         log::debug!("Storing portal logs in clickhouse");
+        let mut portal_logs = portal_logs.peekable();
+        if portal_logs.peek().is_none() {
+            log::debug!("No portal logs to store, skipping empty batch");
+            return Ok(());
+        }
         let mut insert = self.0.insert(&PORTAL_LOGS_TABLE)?;
         for row in portal_logs {
             log::trace!("Storing portal log {:?}", row);

--- a/crates/logs-collector/Cargo.toml
+++ b/crates/logs-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logs-collector"
-version = "2.1.7"
+version = "2.1.8"
 edition = "2021"
 
 [dependencies]

--- a/crates/pings-collector/Cargo.toml
+++ b/crates/pings-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pings-collector"
-version = "2.4.5"
+version = "2.4.6"
 edition = "2021"
 
 [dependencies]

--- a/crates/portal-logs-collector/Cargo.toml
+++ b/crates/portal-logs-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portal-logs-collector"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Problem

If 0 logs were collected for whatever reason, the Clickhouse insertion panics on `unreachable!()`.

## Fix

Peek the iterator in each `store_*` method and return early without opening an insert when the batch is empty. Applied to all three storage methods (`store_logs`, `store_heartbeats`, `store_portal_logs`) since they share the same pattern and latent bug.