### PR TITLE
Stop collecting logs once the buffer is full

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "logs-collector"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/logs-collector/Cargo.toml
+++ b/crates/logs-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logs-collector"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2021"
 
 [dependencies]

--- a/crates/logs-collector/src/collector.rs
+++ b/crates/logs-collector/src/collector.rs
@@ -74,6 +74,12 @@ impl<T: Storage + Sync> LogsCollector<T> {
         }
     }
 
+    /// Whether the buffer has reached its memory limit. Callers use this to stop
+    /// collecting more logs that would only be dropped (see `buffer_logs`).
+    pub fn is_full(&self) -> bool {
+        self.buffer.lock().size >= self.max_buffer_size
+    }
+
     pub async fn dump_buffer(&mut self) -> anyhow::Result<()> {
         let logs = {
             let buffer = self.buffer.get_mut();

--- a/crates/logs-collector/src/server.rs
+++ b/crates/logs-collector/src/server.rs
@@ -117,6 +117,12 @@ where
     }
 
     async fn collect_logs(&self, worker_id: PeerId, mut from_timestamp_ms: u64) {
+        // Don't even request logs we'd have to drop. The buffer drains every round,
+        // so these workers are picked up again next time.
+        if self.logs_collector.is_full() {
+            log::debug!("Buffer full, skipping log collection from {worker_id}");
+            return;
+        }
         let mut last_query_id = None;
         for page in 0..MAX_PAGES {
             if page == 0 {
@@ -161,6 +167,10 @@ where
                 .buffer_logs(worker_id, logs.queries_executed);
 
             if !logs.has_more {
+                return;
+            }
+            if self.logs_collector.is_full() {
+                log::debug!("Buffer full, stopping log collection from {worker_id}");
                 return;
             }
         }


### PR DESCRIPTION
Avoids the network round-trips, deserialization, and signature checks for workers whose logs would only be dropped. The buffer drains each round, so skipped workers are picked up next time.