### PR TITLE
Bump pings collector to 2.5.3-rc1 NET-384

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio 1.43.0",
  "tower-service",
  "tracing",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "pings-collector"
-version = "2.5.2"
+version = "2.5.3-rc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4885,7 +4885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.9.0",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -6080,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "sqd-contract-client"
 version = "1.3.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=d905db5#d905db59899d97d7a96325993ca307c6989be687"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=11f4230#11f42309cb6e68365c8b7277555108d9cc3d968c"
 dependencies = [
  "async-trait",
  "clap",
@@ -6101,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "sqd-messages"
 version = "2.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=d905db5#d905db59899d97d7a96325993ca307c6989be687"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=11f4230#11f42309cb6e68365c8b7277555108d9cc3d968c"
 dependencies = [
  "bytemuck",
  "flate2",
@@ -6117,7 +6117,7 @@ dependencies = [
 [[package]]
 name = "sqd-network-transport"
 version = "3.1.0"
-source = "git+https://github.com/subsquid/sqd-network.git?rev=d905db5#d905db59899d97d7a96325993ca307c6989be687"
+source = "git+https://github.com/subsquid/sqd-network.git?rev=11f4230#11f42309cb6e68365c8b7277555108d9cc3d968c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
-sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "d905db5",  version = "1.3.0" }
-sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "d905db5", version = "2.1.0", features = ["bitstring"] }
-sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "d905db5", version = "3.1.0" }
+sqd-contract-client = { git = "https://github.com/subsquid/sqd-network.git", rev = "11f4230",  version = "1.3.0" }
+sqd-messages = { git = "https://github.com/subsquid/sqd-network.git", rev = "11f4230", version = "2.1.0", features = ["bitstring"] }
+sqd-network-transport = { git = "https://github.com/subsquid/sqd-network.git", rev = "11f4230", version = "3.1.0" }
 
 # The sqd-network fork builds its crates against its in-tree libp2p-identity (path = "identity"), so
 # consumers must redirect the crates.io libp2p-identity to the same source, otherwise two incompatible

--- a/crates/pings-collector/Cargo.toml
+++ b/crates/pings-collector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pings-collector"
-version = "2.5.2"
+version = "2.5.3-rc1"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
See https://github.com/subsquid/sqd-network/pull/216
Deployed to mainnet at 11:40 UTC today